### PR TITLE
Fix a bug with ES6 annotations

### DIFF
--- a/src/reader/Es6Reader.js
+++ b/src/reader/Es6Reader.js
@@ -58,7 +58,7 @@ Es6Reader.CLASS_REGEX = new RegExp(Es6Reader.CLASS_PATTERN, "i");
 Es6Reader.PROTO_PATTERN = "^this\.(" + Es6Reader.ID + ")=(.+)";
 Es6Reader.PROTO_REGEX = new RegExp(Es6Reader.PROTO_PATTERN, "i");
 
-Es6Reader.DEF_PATTERN = "^(" + Es6Reader.ID + ")\\([a-z0-9_,]*\\){";
+Es6Reader.DEF_PATTERN = "^(" + Es6Reader.ID + ")\\(";
 Es6Reader.DEF_REGEX = new RegExp(Es6Reader.DEF_PATTERN, "i");
 
 /**

--- a/test-case/testcase-es6/classes/A.js
+++ b/test-case/testcase-es6/classes/A.js
@@ -31,6 +31,13 @@ class A {
     method() {
 
     }
+
+    /**
+     * @AnotherMethodAnnotation()
+     */
+    method1(a = 5, ...b) {
+
+    }
 }
 
 module.exports = A;

--- a/test/reader/Es6Reader.test.js
+++ b/test/reader/Es6Reader.test.js
@@ -22,7 +22,7 @@ describe("reader.Es6Reader", function () {
             var reader = new Reader(TEST_FILE);
             reader.read(function (err, annotations) {
                 (!err).should.be.true;
-                annotations.length.should.be.exactly(5);
+                annotations.length.should.be.exactly(6);
                 done();
             });
         });


### PR DESCRIPTION
annotations for methods with default parameters or spreads were not parsed