### PR TITLE
Fix a bug with ES6 Reader

### DIFF
--- a/src/reader/Es6Reader.js
+++ b/src/reader/Es6Reader.js
@@ -104,7 +104,6 @@ Es6Reader.prototype.parse = function (callback) {
     try {
         while (this.tokenizer.hasMoreTokens()) {
             token = this.tokenizer.nextToken();
-
             if (this.state === Es6Reader.State.READING) {
                 if (token === "/**") {
                     this.state = Es6Reader.State.IN_COMMENT;
@@ -115,7 +114,7 @@ Es6Reader.prototype.parse = function (callback) {
 
             // Parse annotations
             if (this.state === Es6Reader.State.IN_ANNOTATION) {
-                if (token[0] === "@" || token === "*") {
+                if (token[0] === "@" || token === "*" || token === "*/") {
                     annotation = "";
                     this.state = Es6Reader.State.IN_COMMENT;
                 } else {
@@ -150,6 +149,12 @@ Es6Reader.prototype.parse = function (callback) {
 
             // Parse annotation target
             if (this.state === Es6Reader.State.IN_TARGET) {
+
+                if (block.length === 0) {
+                    this.state = Es6Reader.State.READING;
+                    continue;
+                }
+
                 var found = false,
                     matches;
                 target += token;

--- a/test-case/testcase-es6/classes/A.js
+++ b/test-case/testcase-es6/classes/A.js
@@ -4,14 +4,20 @@
  */
 class A {
 
+    /**
+     * @public
+     * @ConstructorAnnotations()
+     */
     constructor() {
 
         /**
+         * @private
          * @PropertyAnnotation()
          */
         this.prop = null;
 
         /**
+         * @private
          * @PropertyAnnotation()
          */
         this.prop2 = null;

--- a/test/reader/Es6Reader.test.js
+++ b/test/reader/Es6Reader.test.js
@@ -22,7 +22,7 @@ describe("reader.Es6Reader", function () {
             var reader = new Reader(TEST_FILE);
             reader.read(function (err, annotations) {
                 (!err).should.be.true;
-                annotations.length.should.be.exactly(6);
+                annotations.length.should.be.exactly(7);
                 done();
             });
         });


### PR DESCRIPTION
Constructor() annotations were not parsed and were assigned to the first property