### PR TITLE
Fixed a bug occuring when using several backslashes in code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "violin-annotations",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Annotation parser for Node.js",
   "main": "src/Parser.js",
   "directories": {

--- a/src/reader/tokenizer/Tokenizer.js
+++ b/src/reader/tokenizer/Tokenizer.js
@@ -52,15 +52,22 @@ Tokenizer.prototype.nextToken = function () {
         return "";
     }
 
-    var token = "";
+    var token = "",
+        backslashesCount = 0;
     for (var i = this.pos; i < this.str.length; i++) {
         var c = this.str[i];
+
         this.pos++;
 
-        if (c === '"') {
-            if (this.str[i - 1] !== "\\") {
-                this.inString = !this.inString;
+        if (c === '\\') {
+            backslashesCount++;
+        } else {
+            if (c === '"') {
+                if (backslashesCount % 2 === 0) {
+                    this.inString = !this.inString;
+                }
             }
+            backslashesCount = 0;
         }
 
         if (c.match(Tokenizer.WHITE_SPACES) && !this.inString) {

--- a/test-case/testcase-es5/classes/A.js
+++ b/test-case/testcase-es5/classes/A.js
@@ -1,7 +1,7 @@
 /**
  * Test class
  * @constructor
- * @ns.ClassAnnotation("a=b", 0, d=0.5, s="string = \"{}\"", t={"a", "b{}", {"d"}, {}}, i=0)
+ * @ns.ClassAnnotation("a=b", 0, d=0.5, s="string = \"{}\"", t={"a", "b{}", {"d"}, {}}, i=0, j="quote = \"b\\\"")
  * @AnotherAnnotation()
  * @MethodAnnotation()
  */
@@ -24,7 +24,7 @@ A.prototype.b = null;
  * @MethodAnnotation()
  */
 A.prototype.c = function () {
-    var a = {};
+	var a = {};
 }
 
 /**


### PR DESCRIPTION
Just a simple bugfix proposal. When using structures such as: 
```
@annotation(some="quoted_text_backslashes\\")
```
tokenizer didn't recognize string end and failed to parse: now, it does =)
